### PR TITLE
getBulkRequest fixed

### DIFF
--- a/Piwik.php
+++ b/Piwik.php
@@ -582,12 +582,19 @@ class Piwik {
 
 	/**
 	 * Get the result of multiple requests bundled together
-	 *
-	 * @param array $urls
+	 * Take as an argument an array of the API methods to send together
+         * For example, array('API.get', 'Action.get', 'DeviceDetection.getType') 
+         *
+	 * @param array $methods 
 	 */
-	public function getBulkRequest($urls = array()) {              
-		return $this->_request('API.getBulkRequest', $urls);
+	public function getBulkRequest($methods = array()) { 
+          $urls = array();
+          foreach ($methods as $key => $method){
+            $urls['urls['.$key.']'] = urlencode('method='.$method);
+          }    
+	  return $this->_request('API.getBulkRequest', $urls);
 	}
+	
 	/**
 	 * MODULE: ACTIONS
 	 * Reports for visitor actions


### PR DESCRIPTION
getBulkRequest methods need to create html arguments with the following format:
urls[0]=(url encoded url)&urls[1]=(url encoded url)

The previous method does not conform to this format and so it could send only 1 request at a time, defeating the purpose of multiple requests. 

Fixed to build correct format of request. 
